### PR TITLE
feat: Add bottom navigation and My Device page

### DIFF
--- a/lib/components/main_screen.dart
+++ b/lib/components/main_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import 'my_device.dart';
+
+class MainScreen extends StatefulWidget {
+  const MainScreen({super.key});
+
+  @override
+  State<MainScreen> createState() => _MainScreenState();
+}
+
+class _MainScreenState extends State<MainScreen> {
+  int _selectedIndex = 0;
+
+  final List<Widget> _pages = [
+    const MyDevicePage(),
+    const Center(child: Text('Agent Page - Coming Soon')),
+    const Center(child: Text('Discover Page - Coming Soon')),
+    const Center(child: Text('Menu Page - Coming Soon')),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        type: BottomNavigationBarType.fixed,
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.devices), label: 'My Device'),
+          BottomNavigationBarItem(icon: Icon(Icons.smart_toy), label: 'Agent'),
+          BottomNavigationBarItem(icon: Icon(Icons.explore), label: 'Discover'),
+          BottomNavigationBarItem(icon: Icon(Icons.menu), label: 'Menu'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/my_device.dart
+++ b/lib/components/my_device.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+
+import '../utils/device_status_service.dart';
+
+class MyDevicePage extends StatefulWidget {
+  const MyDevicePage({super.key});
+
+  @override
+  State<MyDevicePage> createState() => _MyDevicePageState();
+}
+
+class _MyDevicePageState extends State<MyDevicePage> {
+  final _deviceStatusService = DeviceStatusService();
+  Map<String, int> _batteryLevels = {};
+  Map<String, double> _temperatures = {};
+  Map<String, dynamic> _deviceInfo = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _deviceStatusService.startMonitoring();
+    _loadDeviceInfo();
+    _deviceStatusService.batteryStream.listen((levels) {
+      setState(() {
+        _batteryLevels = levels;
+      });
+    });
+    _deviceStatusService.temperatureStream.listen((temps) {
+      setState(() {
+        _temperatures = temps;
+      });
+    });
+  }
+
+  Future<void> _loadDeviceInfo() async {
+    final info = await _deviceStatusService.getDeviceInfo();
+    setState(() {
+      _deviceInfo = info;
+    });
+  }
+
+  @override
+  void dispose() {
+    _deviceStatusService.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('My Device'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              // TODO: Navigate to settings
+            },
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildDeviceCard(),
+            const SizedBox(height: 16),
+            _buildBatteryStatus(),
+            const SizedBox(height: 16),
+            _buildTemperatureStatus(),
+            const SizedBox(height: 16),
+            _buildDeviceInfo(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDeviceCard() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            const Icon(Icons.earbuds, size: 64),
+            const SizedBox(height: 16),
+            Text('Solana Earphone', style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 8),
+            Text('Connected', style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.green)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBatteryStatus() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Battery Status', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildBatteryIndicator('Left', _batteryLevels['left'] ?? 0),
+                _buildBatteryIndicator('Right', _batteryLevels['right'] ?? 0),
+                _buildBatteryIndicator('Case', _batteryLevels['case'] ?? 0),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBatteryIndicator(String label, int percentage) {
+    return Column(
+      children: [
+        Icon(Icons.battery_full, size: 32, color: percentage > 20 ? Colors.green : Colors.red),
+        const SizedBox(height: 8),
+        Text(label),
+        Text('$percentage%'),
+      ],
+    );
+  }
+
+  Widget _buildTemperatureStatus() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Temperature', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildTemperatureIndicator('Left', _temperatures['left'] ?? 0.0),
+                _buildTemperatureIndicator('Right', _temperatures['right'] ?? 0.0),
+                _buildTemperatureIndicator('Ambient', _temperatures['ambient'] ?? 0.0),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTemperatureIndicator(String label, double temperature) {
+    return Column(
+      children: [
+        Icon(Icons.thermostat, size: 32, color: temperature > 40 ? Colors.red : Colors.blue),
+        const SizedBox(height: 8),
+        Text(label),
+        Text('${temperature.toStringAsFixed(1)}°C'),
+      ],
+    );
+  }
+
+  Widget _buildDeviceInfo() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Device Information', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 16),
+            _buildInfoRow('Firmware', _deviceInfo['firmwareVersion'] ?? 'N/A'),
+            _buildInfoRow('Hardware', _deviceInfo['hardwareVersion'] ?? 'N/A'),
+            _buildInfoRow('Serial Number', _deviceInfo['serialNumber'] ?? 'N/A'),
+            _buildInfoRow('Manufacturing Date', _deviceInfo['manufacturingDate'] ?? 'N/A'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.bodyMedium),
+          Text(value, style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 
+import 'components/main_screen.dart';
+import 'components/signin.dart';
+import 'components/signup.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -7,116 +11,13 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      title: 'Solana Earphone',
+      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple), useMaterial3: true),
+      initialRoute: '/signin',
+      routes: {'/signin': (context) => const SignInPage(), '/signup': (context) => const SignUpPage(), '/home': (context) => const MainScreen()},
     );
   }
 }


### PR DESCRIPTION
This commit implements the bottom navigation bar and My Device page with the following features:

1. Bottom Navigation
- Added 4 main navigation items (My Device, Agent, Discover, Menu)
- Implemented page switching functionality
- Used Material Design icons and labels

2. My Device Page
- Device status overview with connection status
- Real-time battery monitoring for both earbuds and case
- Temperature monitoring with visual indicators
- Detailed device information display

3. Navigation System
- Updated main.dart with new routes
- Implemented proper navigation flow
- Added placeholder pages for future implementation

Technical details:
- Used BottomNavigationBar for navigation
- Implemented real-time data monitoring
- Added responsive layout with cards
- Used Material Design 3 components

Note: Agent, Discover, and Menu pages are currently placeholders